### PR TITLE
feat: change Career Stages horizontal nav link

### DIFF
--- a/Childrens-Social-Care-CPD/Views/Shared/_ErrorLayout.cshtml
+++ b/Childrens-Social-Care-CPD/Views/Shared/_ErrorLayout.cshtml
@@ -57,7 +57,7 @@
                         </a>
                     </li>
                     <li class="dfe-header__navigation-item" id="mmi-career">
-                        <a class="dfe-header__navigation-link" href="/career-stages/practitioner">
+                        <a class="dfe-header__navigation-link" href="/career-stages">
                             Career stages
                             <svg class="dfe-icon dfe-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
                                 <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>

--- a/Childrens-Social-Care-CPD/Views/Shared/_Header.cshtml
+++ b/Childrens-Social-Care-CPD/Views/Shared/_Header.cshtml
@@ -53,7 +53,7 @@
             <ul class="dfe-header__navigation-list">
                 @{
                     RenderMenuItem("home", "Home", "home", category == "Home");
-                    RenderMenuItem("career", "Career stages", "career-stages/practitioner", category == "Career information");
+                    RenderMenuItem("career", "Career stages", "career-stages", category == "Career information");
                     RenderMenuItem("developmentProgrammes", "Development programmes", "development-programmes", category == "Development programmes");
                     RenderMenuItem("exploreRoles", "Explore roles", "explore-roles", category == "Explore roles");
 


### PR DESCRIPTION
As per ticket - change Career Stages horizontal nav link so it takes the user to _/career-stages_, rather than dropping them straight into _/career-stages/practitioner_