### PR TITLE
Pathways page breadcrumbs adjustment 

### DIFF
--- a/Childrens-Social-Care-CPD-Tests/Contentful/Navigation/PathwaysNavigationHelperTests.cs
+++ b/Childrens-Social-Care-CPD-Tests/Contentful/Navigation/PathwaysNavigationHelperTests.cs
@@ -143,6 +143,29 @@ public class PathwaysNavigationHelperTests
         sut.Next.Name.Should().Be("Start pathway");
     }
 
+    [Test]
+    public void Page_Of_Type_Pathways_Overview_Page_Should_Have_Correct_Breadcrumb_Location()
+    {
+        // setup
+        var page = new Content()
+        {
+            PageType = PageType.PathwaysOverviewPage,
+        };
+
+        var pathwaysIndexPage = new Content()
+        {
+            Id = "pathways_index",
+            ContentTitle = "PATHWAYS INDEX"
+        };
+
+        // act
+        var sut = new PathwaysNavigationHelper(page, pathwaysIndexPage);
+
+        // assert
+        sut.BreadcrumbText.Name.Should().Be("Back to PATHWAYS INDEX");
+        sut.BreadcrumbText.Url.Should().Be("/pathways_index");
+    }
+
     #endregion
 
     #region Contents Page
@@ -260,6 +283,31 @@ public class PathwaysNavigationHelperTests
         // assert
         sut.Previous.Url.Should().Be("/START_PAGE_ID");
         sut.Previous.Name.Should().Be("Back to START_PAGE_BREADCRUMB_TEXT");
+    }
+
+    [Test]
+    public void Page_Of_Type_Pathways_Contents_Page_Should_Have_Correct_Breadcrumb_Location()
+    {
+        var page = new Content
+        {
+            PageType = PageType.PathwaysContentsPage,
+            Id = "PAGE_ID",
+            PathwaysModule = new PathwaysModule
+            {
+                OverviewPage = new Content
+                {
+                    Id = "START_PAGE_ID",
+                    ContentTitle = "START_PAGE_CONTENT_TITLE"
+                }
+            }
+        };
+
+        // act
+        var sut = new PathwaysNavigationHelper(page);
+
+        // assert
+        sut.BreadcrumbText.Name.Should().Be("Back to START_PAGE_CONTENT_TITLE");
+        sut.BreadcrumbText.Url.Should().Be("/START_PAGE_ID");
     }
 
     #endregion

--- a/Childrens-Social-Care-CPD-Tests/Controllers/ContentControllerBreadcrumbTests.cs
+++ b/Childrens-Social-Care-CPD-Tests/Controllers/ContentControllerBreadcrumbTests.cs
@@ -1,4 +1,5 @@
 ﻿using Childrens_Social_Care_CPD;
+using Childrens_Social_Care_CPD.Configuration;
 using Childrens_Social_Care_CPD.Contentful;
 using Childrens_Social_Care_CPD.Contentful.Models;
 using Childrens_Social_Care_CPD.Controllers;
@@ -23,6 +24,7 @@ public class ContentControllerBreadcrumbTests
     private HttpContext _httpContext;
     private HttpRequest _httpRequest;
     private ICpdContentfulClient _contentfulClient;
+    private IApplicationConfiguration _applicationConfiguration;
 
     private void SetContent(List<KeyValuePair<string, Content>> content)
     {
@@ -69,6 +71,7 @@ public class ContentControllerBreadcrumbTests
     [SetUp]
     public void SetUp()
     {
+        _applicationConfiguration = Substitute.For<IApplicationConfiguration>();
         _cookies = Substitute.For<IRequestCookieCollection>();
         _httpContext = Substitute.For<HttpContext>();
         _httpRequest = Substitute.For<HttpRequest>();
@@ -81,7 +84,7 @@ public class ContentControllerBreadcrumbTests
 
         _contentfulClient = Substitute.For<ICpdContentfulClient>();
 
-        _contentController = new ContentController(_contentfulClient)
+        _contentController = new ContentController(_contentfulClient, _applicationConfiguration)
         {
             ControllerContext = controllerContext,
             TempData = Substitute.For<ITempDataDictionary>()

--- a/Childrens-Social-Care-CPD-Tests/Controllers/ContentControllerTests.cs
+++ b/Childrens-Social-Care-CPD-Tests/Controllers/ContentControllerTests.cs
@@ -1,4 +1,5 @@
-﻿using Childrens_Social_Care_CPD.Contentful;
+﻿using Childrens_Social_Care_CPD.Configuration;
+using Childrens_Social_Care_CPD.Contentful;
 using Childrens_Social_Care_CPD.Contentful.Models;
 using Childrens_Social_Care_CPD.Controllers;
 using Childrens_Social_Care_CPD.Models;
@@ -21,6 +22,7 @@ public class ContentControllerTests
     private HttpContext _httpContext;
     private HttpRequest _httpRequest;
     private ICpdContentfulClient _contentfulClient;
+    private IApplicationConfiguration _applicationConfiguration;
 
     private void SetContent(Content content)
     {
@@ -38,6 +40,7 @@ public class ContentControllerTests
     [SetUp]
     public void SetUp()
     {
+        _applicationConfiguration = Substitute.For<IApplicationConfiguration>();
         _cookies = Substitute.For<IRequestCookieCollection>();
         _httpContext = Substitute.For<HttpContext>();
         _httpRequest = Substitute.For<HttpRequest>();
@@ -49,7 +52,7 @@ public class ContentControllerTests
 
         _contentfulClient = Substitute.For<ICpdContentfulClient>();
 
-        _contentController = new ContentController(_contentfulClient)
+        _contentController = new ContentController(_contentfulClient, _applicationConfiguration)
         {
             ControllerContext = controllerContext,
             TempData = Substitute.For<ITempDataDictionary>()

--- a/Childrens-Social-Care-CPD-Tests/MockApplicationConfiguration.cs
+++ b/Childrens-Social-Care-CPD-Tests/MockApplicationConfiguration.cs
@@ -26,6 +26,7 @@ public class MockApplicationConfiguration : IApplicationConfiguration
     public string _azureManagedIdentityId = null;
     public string _azureStorageAccount = null;
     public string _azureStorageAccountUriFormatString = null;
+    public string _pathwaysIndexPage = null;
 
     public string AppInsightsConnectionString => _appInsightsConnectionString;
     public string AppVersion => _appVersion;
@@ -50,6 +51,7 @@ public class MockApplicationConfiguration : IApplicationConfiguration
     public string AzureManagedIdentityId => _azureManagedIdentityId;
     public string AzureStorageAccount => _azureStorageAccount;
     public string AzureStorageAccountUriFormatString => _azureStorageAccountUriFormatString;
+    public string PathwaysIndexPage => _pathwaysIndexPage;
 
     public void SetAllValid(string value = "foo")
     {
@@ -75,5 +77,6 @@ public class MockApplicationConfiguration : IApplicationConfiguration
         _azureManagedIdentityId = value;
         _azureStorageAccount = value;
         _azureStorageAccountUriFormatString = value;
+        _pathwaysIndexPage = value;
     }
 }

--- a/Childrens-Social-Care-CPD/Configuration/ApplicationConfiguration.cs
+++ b/Childrens-Social-Care-CPD/Configuration/ApplicationConfiguration.cs
@@ -16,6 +16,7 @@ public class ApplicationConfiguration(IConfiguration configuration) : IApplicati
     public int FeaturePollingInterval => int.TryParse(configuration["CPD_FEATURE_POLLING_INTERVAL"], out var result) ? result : 0;
     public string GitHash => configuration["VCS-REF"];
     public string GoogleTagManagerKey => configuration["CPD_GOOGLEANALYTICSTAG"];
+    public string PathwaysIndexPage => "pathways-social-work-leadership-modules/available-pathways";
     public string SearchApiKey => configuration["CPD_SEARCH_CLIENT_API_KEY"];
     public string SearchEndpoint => configuration["CPD_SEARCH_ENDPOINT"];
     public string SearchIndexName => configuration["CPD_SEARCH_INDEX_NAME"];

--- a/Childrens-Social-Care-CPD/Configuration/IApplicationConfiguration.cs
+++ b/Childrens-Social-Care-CPD/Configuration/IApplicationConfiguration.cs
@@ -47,4 +47,7 @@ public interface IApplicationConfiguration
 
     [RequiredForEnvironment(ApplicationEnvironment.All, Hidden = false)]
     string GoogleTagManagerKey { get; }
+    [RequiredForEnvironment(ApplicationEnvironment.All, Hidden = false)]
+    string PathwaysIndexPage { get; }
+
 }

--- a/Childrens-Social-Care-CPD/Contentful/Navigation/INavigationHelper.cs
+++ b/Childrens-Social-Care-CPD/Contentful/Navigation/INavigationHelper.cs
@@ -6,4 +6,5 @@ public interface INavigationHelper
     public NavigationLocation Previous { get; }
     public NavigationLocation AvailablePathwaysPage { get; }
     public LocationInfo CurrentLocation { get; }
+    public NavigationLocation BreadcrumbText { get; }
 }

--- a/Childrens-Social-Care-CPD/Contentful/Navigation/PathwaysNavigationHelper.cs
+++ b/Childrens-Social-Care-CPD/Contentful/Navigation/PathwaysNavigationHelper.cs
@@ -12,6 +12,7 @@ public class PathwaysNavigationHelper : INavigationHelper
         Url = "/pathways-social-work-leadership-modules/available-pathways"
     };
     private LocationInfo _currentLocation;
+    private NavigationLocation _breadcrumbText;
 
 
     // properties
@@ -47,7 +48,15 @@ public class PathwaysNavigationHelper : INavigationHelper
         }
     }
 
-    public PathwaysNavigationHelper(Content page)
+    public NavigationLocation BreadcrumbText
+    {
+        get
+        {
+            return _breadcrumbText;
+        }
+    }
+
+    public PathwaysNavigationHelper(Content page, Content pathwaysIndex = null)
     {
         switch (page.PageType)
         {
@@ -69,6 +78,13 @@ public class PathwaysNavigationHelper : INavigationHelper
                         ? "Start module"
                         : "Start pathway"
                 };
+
+                this._breadcrumbText = new NavigationLocation
+                {
+                    Url = "/" + pathwaysIndex?.Id,
+                    Name = "Back to " + pathwaysIndex?.ContentTitle
+                };
+
                 break;
 
             case PageType.PathwaysContentsPage:
@@ -83,6 +99,13 @@ public class PathwaysNavigationHelper : INavigationHelper
                     Url = "/" + page.PathwaysModule?.OverviewPage?.Id,
                     Name = "Back to " + page.PathwaysModule?.OverviewPage?.BreadcrumbText
                 };
+
+                this._breadcrumbText = new NavigationLocation
+                {
+                    Url = "/" + page.PathwaysModule?.OverviewPage?.Id,
+                    Name = "Back to " + page.PathwaysModule?.OverviewPage?.ContentTitle
+                };
+
                 break;
 
             case PageType.PathwaysTrainingContent:

--- a/Childrens-Social-Care-CPD/Views/Shared/_BreadcrumbTrail.cshtml
+++ b/Childrens-Social-Care-CPD/Views/Shared/_BreadcrumbTrail.cshtml
@@ -18,7 +18,7 @@
                     ? Model.PathwaysModule.OverviewPage
                     : Model.PathwaysModule.ContentsPage;
 
-                string linkText = navigationPage.BreadcrumbText ?? navigationPage.Title;
+                string linkText = navigationPage.BreadcrumbText ?? navigationPage.ContentTitle;
 
                 <li class="govuk-breadcrumbs__list-item">
                     &lt;
@@ -31,8 +31,8 @@
             case PageType.PathwaysOverviewPage:
                 <li class="govuk-breadcrumbs__list-item">
                     &lt;
-                    <a class="govuk-breadcrumbs__link" href="@contextModel.NavigationHelper.AvailablePathwaysPage.Url">
-                        Back to Available pathways
+                    <a class="govuk-breadcrumbs__link" href="@contextModel.NavigationHelper.BreadcrumbText.Url">
+                        @contextModel.NavigationHelper.BreadcrumbText.Name
                     </a>
                 </li>
             break;
@@ -40,8 +40,8 @@
             case PageType.PathwaysContentsPage:
                 <li class="govuk-breadcrumbs__list-item">
                     &lt;
-                    <a class="govuk-breadcrumbs__link" href="@contextModel.NavigationHelper.Previous.Url">
-                        @contextModel.NavigationHelper.Previous.Name
+                    <a class="govuk-breadcrumbs__link" href="@contextModel.NavigationHelper.BreadcrumbText.Url">
+                        @contextModel.NavigationHelper.BreadcrumbText.Name
                     </a>
                 </li>
             break;


### PR DESCRIPTION
Changed the breadcrumb text for pathways overview, contents, and training content match the ContentTitle of the previous page.