### PR TITLE
fix: nav menu current page rule amended and corresponding test altered

### DIFF
--- a/Childrens-Social-Care-CPD/Views/Shared/_NavigationMenu.cshtml
+++ b/Childrens-Social-Care-CPD/Views/Shared/_NavigationMenu.cshtml
@@ -41,7 +41,7 @@
         {
             string pageName = $"/{ViewBag.ContextModel.PageName}";
             string uri = menuItem.Uri.StartsWith('/') ? menuItem.Uri : $"/{menuItem.Uri}";
-            var css = pageName.StartsWith(uri)
+            var css = pageName.Equals(uri)
                 ? "dfe-vertical-nav__section-item  dfe-vertical-nav__section-item--current"
                 : "dfe-vertical-nav__section-item";
 

--- a/browser-tests/regression-tests/tests/nav-menu.spec.ts
+++ b/browser-tests/regression-tests/tests/nav-menu.spec.ts
@@ -79,7 +79,7 @@ test.describe('Navigation Menu without Header', () => {
         elements['nav-link-containers'] = elements['container'].locator('li');
         elements['inactive-nav-element-container'] = elements['nav-link-containers'].locator('nth=0');
         elements['inactive-nav-element'] = elements['inactive-nav-element-container'].locator('a');
-        elements['active-nav-element-container'] = elements['nav-link-containers'].locator('nth=2');
+        elements['active-nav-element-container'] = elements['nav-link-containers'].locator('nth=3');
         elements['active-nav-element'] = elements['active-nav-element-container'].locator('a');
     });
 
@@ -100,7 +100,7 @@ test.describe('Navigation Menu without Header', () => {
 
     test('Nav items', async ({ page }) => {
 
-        await expect(elements['nav-link-containers']).toHaveCount(16);
+        await expect(elements['nav-link-containers']).toHaveCount(19);
 
         // an inactive (not current page) nav item
         await expect(elements['inactive-nav-element-container']).toHaveCSS('border-left', '4px solid rgb(177, 180, 182)');


### PR DESCRIPTION
Code altered so that navigation menu 'current page' focus is strictly when a url is the same as the current browser page, rather than just when it 'starts with' the same text. 
As detailed in ticket 3349 https://dfedigital.atlassian.net/browse/SFSW-3349 