### PR TITLE
Rich text block headings

### DIFF
--- a/Childrens-Social-Care-CPD-Tests/Contentful/Renderers/Heading1RendererTests.cs
+++ b/Childrens-Social-Care-CPD-Tests/Contentful/Renderers/Heading1RendererTests.cs
@@ -50,7 +50,7 @@ public class Heading1RendererTests
         var actual = stringWriter.ToString();
 
         // assert
-        actual.Should().Be("<h1>AAA</h1>");
+        actual.Should().Be("<h1 class=\"HtmlEncode[[govuk-heading-xl]]\">AAA</h1>");
     }
 
     [Test]

--- a/Childrens-Social-Care-CPD-Tests/Contentful/Renderers/Heading2RendererTests.cs
+++ b/Childrens-Social-Care-CPD-Tests/Contentful/Renderers/Heading2RendererTests.cs
@@ -50,7 +50,7 @@ public class Heading2RendererTests
         var actual = stringWriter.ToString();
 
         // assert
-        actual.Should().Be("<h2>AAA</h2>");
+        actual.Should().Be("<h2 class=\"HtmlEncode[[govuk-heading-l]]\">AAA</h2>");
     }
 
     [Test]

--- a/Childrens-Social-Care-CPD-Tests/Contentful/Renderers/Heading3RendererTests.cs
+++ b/Childrens-Social-Care-CPD-Tests/Contentful/Renderers/Heading3RendererTests.cs
@@ -50,7 +50,7 @@ public class Heading3RendererTests
         var actual = stringWriter.ToString();
 
         // assert
-        actual.Should().Be("<h3>AAA</h3>");
+        actual.Should().Be("<h3 class=\"HtmlEncode[[govuk-heading-m]]\">AAA</h3>");
     }
 
     [Test]

--- a/Childrens-Social-Care-CPD-Tests/Contentful/Renderers/Heading4RendererTests.cs
+++ b/Childrens-Social-Care-CPD-Tests/Contentful/Renderers/Heading4RendererTests.cs
@@ -50,7 +50,7 @@ public class Heading4RendererTests
         var actual = stringWriter.ToString();
 
         // assert
-        actual.Should().Be("<h4>AAA</h4>");
+        actual.Should().Be("<h4 class=\"HtmlEncode[[govuk-heading-s]]\">AAA</h4>");
     }
 
     [Test]

--- a/Childrens-Social-Care-CPD/Contentful/Renderers/HeadingsRenderer.cs
+++ b/Childrens-Social-Care-CPD/Contentful/Renderers/HeadingsRenderer.cs
@@ -29,7 +29,16 @@ internal class HeadingRendererBase(IRenderer<Text> textRenderer, IRenderer<Hyper
                         }
                         break;
                     }
-                case Text text: h.InnerHtml.AppendHtml(textRenderer.Render(text)); break;
+                case Text text:
+                    h.InnerHtml.AppendHtml(textRenderer.Render(text));
+                    switch (tag)
+                    {
+                        case "h1": h.AddCssClass("govuk-heading-xl"); break;
+                        case "h2": h.AddCssClass("govuk-heading-l"); break;
+                        case "h3": h.AddCssClass("govuk-heading-m"); break;
+                        case "h4": h.AddCssClass("govuk-heading-s"); break;
+                    }
+                break;
                 case Hyperlink hyperlink: h.InnerHtml.AppendHtml(hyperlinkRenderer.Render(hyperlink)); break;
             }
         }

--- a/Childrens-Social-Care-CPD/Views/Shared/_RichTextBlock.cshtml
+++ b/Childrens-Social-Care-CPD/Views/Shared/_RichTextBlock.cshtml
@@ -17,17 +17,17 @@
                 case 2:
                 default:
                     level = "2";
-                    cssClass = "govuk-heading-m";
+                    cssClass = "govuk-heading-l";
                 break;
 
                 case 1:
                     level = "1";
-                    cssClass = "govuk-heading-l";
+                    cssClass = "govuk-heading-xl";
                 break;
 
                 case 3:
                     level = "3";
-                    cssClass = "govuk-heading-s";
+                    cssClass = "govuk-heading-m";
                 break;
             }
 

--- a/browser-tests/regression-tests/tests/rich-text-block.spec.ts
+++ b/browser-tests/regression-tests/tests/rich-text-block.spec.ts
@@ -14,7 +14,7 @@ test.describe('Rich Text Block', () => {
 
     test('Padding and Margins', async ({ page }) => {
         await expect(elements["header"]).toBeVisible();
-        await expect(elements["header"]).toHaveCSS('padding-top', '10px');
+        await expect(elements["header"]).toHaveCSS('padding-top', '20px');
         await expect(elements["header"]).toHaveCSS('margin-bottom', '24px');
 
         await expect(elements["text"]).toBeVisible();
@@ -22,10 +22,10 @@ test.describe('Rich Text Block', () => {
     });
 
     test('Title formatting', async ({ page }) => {
-        await expect(elements["header"]).toHaveClass('govuk-heading-m');
-        await expect(elements["header"]).toHaveCSS('font-size', '24px');
+        await expect(elements["header"]).toHaveClass('govuk-heading-l');
+        await expect(elements["header"]).toHaveCSS('font-size', '32px');
         await expect(elements["header"]).toHaveCSS('font-weight', '700');
-        await expect(elements["header"]).toHaveCSS('line-height', '31.9999px');
+        await expect(elements["header"]).toHaveCSS('line-height', '42.6666px');
     });
     
     test('Normal text formatting', async ({ page }) => {


### PR DESCRIPTION
The headings displayed on rich text blocks were not correct, and this PR rectifies that by:

* adjusting the css class applied to h1/h2/h3 tags created for the block header field
* applying appropriate css classes to the header tags inline in the text of the block