### PR TITLE
Remove sticky back-to-top from DOM when not required

### DIFF
--- a/Childrens-Social-Care-CPD/Views/Shared/_SiteLayout.cshtml
+++ b/Childrens-Social-Care-CPD/Views/Shared/_SiteLayout.cshtml
@@ -53,7 +53,7 @@
         import { initAll } from '/javascript/govuk-frontend.min.js'
         initAll()
     </script>
-    <script src="/javascript/components/back-to-top-202511191127.js" type="module"></script>
+    <script src="/javascript/components/back-to-top-202512031507.js" type="module"></script>
     @await RenderSectionAsync("Scripts", required: false)
     @Html.RenderScripts(ScriptPosition.BodyEnd)
 </body>

--- a/Childrens-Social-Care-CPD/wwwroot/javascript/components/back-to-top-202512031507.js
+++ b/Childrens-Social-Care-CPD/wwwroot/javascript/components/back-to-top-202512031507.js
@@ -26,7 +26,7 @@ function ContentsListWithBody(element) {
 ContentsListWithBody.prototype.init = function () {
     if (!this.stickyElement) return;
     if (!this.staticElement) {
-        this.hide();
+        this.destroy();
         return;
     }
     window.onresize = this.onResize.bind(this);
@@ -143,6 +143,10 @@ ContentsListWithBody.prototype.show = function () {
     this.stickyElement.classList.add("gem-c-contents-list-with-body__sticky-element--stuck-to-window");
     this.stickyElement.classList.remove("gem-c-contents-list-with-body__sticky-element--hidden");
     this.hidden = false;
+};
+
+ContentsListWithBody.prototype.destroy = function () {
+    this.stickyElement.remove();
 };
 
 document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
There was an accessibility fault reported with the sticky back-to-top control being accessible by keyboard on pages where it wasn't appearing visually.  This PR rectifies that by completely removing it on pages where it isn't required.