### PR TITLE
SFSW-3606

### DIFF
--- a/.github/actions/run-accessibility-tests/action.yml
+++ b/.github/actions/run-accessibility-tests/action.yml
@@ -9,13 +9,13 @@ inputs:
 runs:
   using: composite
 
-  steps:
+steps:
     - name: Run Pa11y
       shell: bash
       env:
         CONTAINER_ID: ${{ inputs.container-id }}
       run: |
-        npx pa11y-ci \
+        npx --ignore-scripts pa11y-ci \
         --config .pa11yci-ubuntu.js \
         --sitemap "http://localhost:5001/sitemap.xml" \
         --sitemap-find "https://www.support-for-social-workers.education.gov.uk" \

--- a/.github/actions/run-accessibility-tests/action.yml
+++ b/.github/actions/run-accessibility-tests/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: composite
 
-steps:
+  steps:
     - name: Run Pa11y
       shell: bash
       env:

--- a/.github/workflows/contentful-schema-migrate.yml
+++ b/.github/workflows/contentful-schema-migrate.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install npm packages used by util scripts
         working-directory: ./Contentful-Schema
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Get target environment current migration version
         id: current-migration-version
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Install Contentful CLI
-        run: npm install -g contentful-cli
+        run: npm install -g contentful-cli --ignore-scripts
 
       - name: Login to Contentful with management token
         run: contentful login --management-token "${{ env.MANAGEMENT_TOKEN }}"
@@ -115,10 +115,10 @@ jobs:
 
       - name: Install npm packages used by migration script
         working-directory: ./Contentful-Schema
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Install Contentful CLI
-        run: npm install -g contentful-cli
+        run: npm install -g contentful-cli --ignore-scripts
 
       - name: Extract migration files from archive
         working-directory: ./Contentful-Schema/migrations
@@ -154,7 +154,7 @@ jobs:
 
       - name: Install npm packages used by migration script
         working-directory: ./Contentful-Schema
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Run script to point alias ${{ inputs.target_environment == 'prod' && 'master' || inputs.target_environment }} at new environment ${{ env.STAGING_ENVIRONMENT }}
         working-directory: ./Contentful-Schema/utils

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -27,9 +27,9 @@ jobs:
           cache: "npm"
 
       - name: Install semantic-release
-        run: npm install --global semantic-release@23 @semantic-release/git @semantic-release/github
+        run: npm install --global semantic-release@23 @semantic-release/git @semantic-release/github --ignore-scripts
 
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
-        run: npx semantic-release --debug
+        run: npx --ignore-scripts semantic-release --debug

--- a/.github/workflows/docker-dev-accessibility-tests.yml
+++ b/.github/workflows/docker-dev-accessibility-tests.yml
@@ -38,7 +38,7 @@ jobs:
           node-version: "latest"
 
       - name: Install latest NPM version
-        run: npm install -g npm@latest
+        run: npm install -g npm@latest --ignore-scripts
 
       - name: Verify NPM version
         run: npm version

--- a/.github/workflows/docker-dev-integration-tests.yml
+++ b/.github/workflows/docker-dev-integration-tests.yml
@@ -38,7 +38,7 @@ jobs:
           node-version: "latest"
 
       - name: Install latest NPM version
-        run: npm install -g npm@latest
+        run: npm install -g npm@latest --ignore-scripts
 
       - name: Verify NPM version
         run: npm version

--- a/.github/workflows/link-validation-check.yml
+++ b/.github/workflows/link-validation-check.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install npm packages used by util scripts
         working-directory: ./Utilities
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Scan for broken links
         working-directory: ./Utilities

--- a/.github/workflows/prepare-environment-for-migrations.yml
+++ b/.github/workflows/prepare-environment-for-migrations.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install npm packages used by migration script
         working-directory: ./Contentful-Schema
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Install Contentful CLI
         run: npm install -g contentful-cli

--- a/.github/workflows/prepare-environment-for-migrations.yml
+++ b/.github/workflows/prepare-environment-for-migrations.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Install Contentful CLI
-        run: npm install -g contentful-cli
+        run: npm install -g contentful-cli --ignore-scripts
 
       - name: Run script to create migrationVersion content type
         working-directory: ./Contentful-Schema/utils

--- a/.github/workflows/run-content-regression-tests.yml
+++ b/.github/workflows/run-content-regression-tests.yml
@@ -32,13 +32,13 @@ jobs:
           node-version: 18
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps chromium
+        run: npx --ignore-scripts playwright install --with-deps chromium
 
       - name: Run Playwright tests
-        run: npx playwright test
+        run: npx --ignore-scripts playwright test
 
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
Add ignore scripts flag to NPM/NPM calls to help protect against execution of shell scripts outside of the intended command.

This can occur when a dependancy is compromised and its scripts are executed. Attackers can include malicious scripts that get executed at elevated privilege levels 